### PR TITLE
Aggiornamento docker-compose to docker compose for html-proofer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "develop": "gatsby develop",
     "deploy": "gh-pages -u 'Deploy Bot <no-reply@teamdigitale.governo.it>' -d public",
     "lint": "eslint src --ext .js",
-    "html-proofer": "docker-compose up --build",
+    "html-proofer": "docker compose up --build",
     "pa11y": "sh pa11y.sh",
     "serve": "gatsby serve"
   },


### PR DESCRIPTION
Come da:
https://github.com/teamdigitale/padigitale2026.gov.it-site/commit/59010fbc8fb4e4cd6fbcad7f5461e518a3dbb487